### PR TITLE
feat: ies url resolver to support env variables for setting the ies url

### DIFF
--- a/src/Service/Authentication/UsernamePasswordAuthentication.php
+++ b/src/Service/Authentication/UsernamePasswordAuthentication.php
@@ -4,10 +4,9 @@ declare(strict_types=1);
 
 namespace Atoolo\WebAccount\Service\Authentication;
 
-use Atoolo\Resource\ResourceChannel;
 use Atoolo\WebAccount\Dto\AuthenticationResult;
+use Atoolo\WebAccount\Service\IesUrlResolver;
 use RuntimeException;
-use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
@@ -16,8 +15,7 @@ use Throwable;
 class UsernamePasswordAuthentication
 {
     public function __construct(
-        #[Autowire(service: 'atoolo_resource.resource_channel')]
-        private readonly ResourceChannel $resourceChannel,
+        private readonly IesUrlResolver $iesUrlResolver,
         private readonly HttpClientInterface $client,
         private readonly DenormalizerInterface $denormalizer,
     ) {}
@@ -61,15 +59,13 @@ GRAPHQL;
 
         $payload = ['query' => $query, 'variables' => $variables];
 
-
         $response = $this->client->request(
             'POST',
-            'https://' . $this->resourceChannel->tenant->host . '/api/graphql',
+            $this->iesUrlResolver->getBaseUrl() . '/api/graphql',
             [
                 'json' => $payload,
             ],
         );
-
 
         if (200 !== $response->getStatusCode()) {
             throw new RuntimeException(

--- a/src/Service/Authentication/UsernamePasswordAuthentication.php
+++ b/src/Service/Authentication/UsernamePasswordAuthentication.php
@@ -70,7 +70,7 @@ GRAPHQL;
         if (200 !== $response->getStatusCode()) {
             throw new RuntimeException(
                 'HTTP Status Code from '
-                . $this->resourceChannel->tenant->host
+                . $this->iesUrlResolver->getBaseUrl()
                 . ': '
                 . $response->getStatusCode(),
             );
@@ -81,7 +81,7 @@ GRAPHQL;
         } catch (Throwable $e) {
             throw new RuntimeException(
                 'Response from '
-                . $this->resourceChannel->tenant->host
+                . $this->iesUrlResolver->getBaseUrl()
                 . ' could not be decoded: '
                 . $e->getMessage(),
             );

--- a/src/Service/IesUrlResolver.php
+++ b/src/Service/IesUrlResolver.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atoolo\WebAccount\Service;
+
+use Atoolo\Resource\ResourceChannel;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+class IesUrlResolver
+{
+    public function __construct(
+        #[Autowire(service: 'atoolo_resource.resource_channel')]
+        private readonly ResourceChannel $resourceChannel,
+        #[Autowire('%env(default::IES_SCHEME)%')]
+        private readonly ?string $iesScheme,
+        #[Autowire('%env(default::IES_HOST)%')]
+        private readonly ?string $iesHost,
+        #[Autowire('%env(default::IES_PORT)%')]
+        private readonly ?string $iesPort,
+    ) {}
+
+    public function getBaseUrl(): string
+    {
+        if ($this->iesHost) {
+            $scheme = $this->iesScheme ?: 'https';
+            $port = $this->iesPort ? ':' . $this->iesPort : '';
+            return sprintf('%s://%s%s', $scheme, $this->iesHost, $port);
+        }
+
+        return 'https://' . $this->resourceChannel->tenant->host;
+    }
+}

--- a/test/Service/Authentication/UsernamePasswordAuthenticationTest.php
+++ b/test/Service/Authentication/UsernamePasswordAuthenticationTest.php
@@ -4,13 +4,11 @@ declare(strict_types=1);
 
 namespace Atoolo\WebAccount\Test\Service\Authentication;
 
-use Atoolo\Resource\DataBag;
-use Atoolo\Resource\ResourceChannel;
-use Atoolo\Resource\ResourceTenant;
 use Atoolo\WebAccount\Dto\AuthenticationResult;
 use Atoolo\WebAccount\Dto\AuthenticationStatus;
 use Atoolo\WebAccount\Dto\User;
 use Atoolo\WebAccount\Service\Authentication\UsernamePasswordAuthentication;
+use Atoolo\WebAccount\Service\IesUrlResolver;
 use Exception;
 use JsonException;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -25,7 +23,7 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
 #[CoversClass(UsernamePasswordAuthentication::class)]
 class UsernamePasswordAuthenticationTest extends TestCase
 {
-    private readonly ResourceChannel $resourceChannel;
+    private readonly IesUrlResolver $iesUrlResolver;
     private readonly HttpClientInterface $httpClient;
     private readonly DenormalizerInterface $denormalizer;
     private readonly ResponseInterface $httpResponse;
@@ -33,30 +31,7 @@ class UsernamePasswordAuthenticationTest extends TestCase
 
     protected function setUp(): void
     {
-        $resourceTenant = new ResourceTenant(
-            "",
-            "",
-            "",
-            "test.com",
-            new DataBag([]),
-        );
-
-        $this->resourceChannel = new ResourceChannel(
-            '',
-            '',
-            '',
-            '',
-            false,
-            '',
-            '',
-            '',
-            '',
-            '',
-            '',
-            [],
-            new DataBag([]),
-            $resourceTenant,
-        );
+        $this->iesUrlResolver = $this->createMock(IesUrlResolver::class);
         $this->httpClient = $this->createMock(HttpClientInterface::class);
         $this->httpResponse = $this->createMock(ResponseInterface::class);
         $this->httpClient->method('request')->willReturn($this->httpResponse);
@@ -64,7 +39,7 @@ class UsernamePasswordAuthenticationTest extends TestCase
         $this->denormalizer = $this->createMock(DenormalizerInterface::class);
 
         $this->authentication = new UsernamePasswordAuthentication(
-            $this->resourceChannel,
+            $this->iesUrlResolver,
             $this->httpClient,
             $this->denormalizer,
         );

--- a/test/Service/IesUrlResolverTest.php
+++ b/test/Service/IesUrlResolverTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Atoolo\WebAccount\Test\Service;
+
+use Atoolo\Resource\DataBag;
+use Atoolo\Resource\ResourceChannel;
+use Atoolo\Resource\ResourceTenant;
+use Atoolo\WebAccount\Service\IesUrlResolver;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(IesUrlResolver::class)]
+class IesUrlResolverTest extends TestCase
+{
+    private readonly ResourceChannel $resourceChannel;
+
+    public function setUp(): void
+    {
+        $resourceTenant = new ResourceTenant(
+            "",
+            "",
+            "",
+            "test.com",
+            new DataBag([]),
+        );
+
+        $this->resourceChannel = new ResourceChannel(
+            '',
+            '',
+            '',
+            '',
+            false,
+            '',
+            '',
+            '',
+            '',
+            '',
+            '',
+            [],
+            new DataBag([]),
+            $resourceTenant,
+        );
+    }
+
+    public function testFallbackToResourceChannelHost(): void
+    {
+        $iesUrlResolver = new IesUrlResolver(
+            $this->resourceChannel,
+            null,
+            null,
+            null,
+        );
+
+        $expectedUrl = 'https://' . $this->resourceChannel->tenant->host;
+        $this->assertEquals($expectedUrl, $iesUrlResolver->getBaseUrl());
+    }
+
+    public function testWithCustomIesHost(): void
+    {
+        $iesUrlResolver = new IesUrlResolver(
+            $this->resourceChannel,
+            'https',
+            'custom.ies.host',
+            '443',
+        );
+
+        $expectedUrl = 'https://custom.ies.host:443';
+        $this->assertEquals($expectedUrl, $iesUrlResolver->getBaseUrl());
+    }
+}


### PR DESCRIPTION
The URL to the IES must be able to be set via Env variable so that the e2e-test can set a fake-ies.